### PR TITLE
Make door command admin-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# MinecraftHouses
+
+A simple Spigot plugin that lets players buy or rent houses via signs. House data is stored in `plugins/MinecraftHouses/houses.yml`.
+
+## Building
+
+Requires Maven and Java 8. On Linux/macOS run:
+
+```bash
+mvn package
+```
+
+The resulting JAR can be found in `target/`.
+
+On Windows you can also use `build.bat` which will place the JAR in a `build` folder:
+
+```cmd
+build.bat
+```
+
+## Usage
+
+Place a sign with `[House]` or `[Rent]` on the first line and a price on the second. Players can right-click the sign while sneaking to purchase or rent it. Sneaking and right-clicking again sells the house.
+
+Commands:
+
+- `/houses list` – list all houses
+- `/houses owned` – list houses you own
+- `/houses adddoor <id>` – link a door to a house (admin, right-click the door after running the command)
+- `/houses reload` – reload configuration (admin only)
+
+Only the owner of a house can interact with its doors.

--- a/build.bat
+++ b/build.bat
@@ -1,13 +1,17 @@
 @echo off
-if not defined MAVEN_HOME (
-    mvn -version >nul 2>&1
-    if %ERRORLEVEL% neq 0 (
-        echo Maven is not installed.
-        exit /b 1
-    )
+
+set "MAVEN_CMD=mvn"
+if defined MAVEN_HOME (
+    set "MAVEN_CMD=%MAVEN_HOME%\bin\mvn"
 )
 
-mvn clean package
+%MAVEN_CMD% -version >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo Maven is not installed or not found in PATH.
+    exit /b 1
+)
+
+%MAVEN_CMD% clean package
 if %ERRORLEVEL% neq 0 (
     echo Build failed.
     exit /b %ERRORLEVEL%
@@ -18,6 +22,6 @@ if not exist build (
 )
 
 for /f "delims=" %%i in ('dir /b target^|findstr /i "\.jar$"') do set JAR=%%i
-move /Y target\%JAR% build\%JAR%
+move /Y "target\%JAR%" "build\%JAR%"
 
 echo Build completed. Jar moved to build\%JAR%

--- a/src/main/java/com/example/HousesCommand.java
+++ b/src/main/java/com/example/HousesCommand.java
@@ -54,8 +54,30 @@ public class HousesCommand implements CommandExecutor {
             }
             return true;
         }
+        if (args[0].equalsIgnoreCase("adddoor")) {
+            if (!p.hasPermission("houses.admin")) {
+                p.sendMessage(ChatColor.RED + "No permission");
+                return true;
+            }
+            if (args.length < 2) {
+                p.sendMessage(ChatColor.RED + "/houses adddoor <id>");
+                return true;
+            }
+            int id;
+            try {
+                id = Integer.parseInt(args[1]);
+            } catch (NumberFormatException ex) {
+                p.sendMessage(ChatColor.RED + "Invalid id");
+                return true;
+            }
+            plugin.awaitingDoorAdd.put(p.getUniqueId(), id);
+            plugin.awaitingDoorRemove.remove(p.getUniqueId());
+            p.sendMessage(ChatColor.GREEN + "Right click a door to add to house " + id);
+            return true;
+        }
+
         if (args[0].equalsIgnoreCase("reload")) {
-            if (!p.hasPermission("mchouses.admin")) {
+            if (!p.hasPermission("houses.admin")) {
                 p.sendMessage(ChatColor.RED + "No permission");
                 return true;
             }
@@ -72,29 +94,9 @@ public class HousesCommand implements CommandExecutor {
         p.sendMessage(ChatColor.YELLOW + "Available commands:");
         p.sendMessage(ChatColor.AQUA + "/houses list" + ChatColor.GRAY + " - list all houses");
         p.sendMessage(ChatColor.AQUA + "/houses owned" + ChatColor.GRAY + " - your houses");
-        if (p.hasPermission("mchouses.admin")) {
+        if (p.hasPermission("houses.admin")) {
+            p.sendMessage(ChatColor.AQUA + "/houses adddoor <id>" + ChatColor.GRAY + " - add a door to a house");
             p.sendMessage(ChatColor.AQUA + "/houses reload" + ChatColor.GRAY + " - reload configs");
         }
-    }
-        if (args.length == 0 || args[0].equalsIgnoreCase("list")) {
-            p.sendMessage(ChatColor.YELLOW + "Houses:");
-            for (String id : cfg.getConfigurationSection("houses").getKeys(false)) {
-                String owner = cfg.getString("houses." + id + ".owner");
-                p.sendMessage(ChatColor.GRAY + "#" + id + " owner:" + (owner == null ? "none" : owner));
-            }
-            return true;
-        }
-        if (args[0].equalsIgnoreCase("owned")) {
-            p.sendMessage(ChatColor.YELLOW + "Owned houses:");
-            for (String id : cfg.getConfigurationSection("houses").getKeys(false)) {
-                String owner = cfg.getString("houses." + id + ".owner");
-                if (p.getUniqueId().toString().equals(owner)) {
-                    p.sendMessage(ChatColor.GREEN + "#" + id);
-                }
-            }
-            return true;
-        }
-        p.sendMessage(ChatColor.RED + "Unknown subcommand");
-        return true;
     }
 }

--- a/src/main/java/com/example/MinecraftHouses.java
+++ b/src/main/java/com/example/MinecraftHouses.java
@@ -26,6 +26,9 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     private File housesFile;
     private FileConfiguration housesConfig;
 
+    public final Map<UUID, Integer> awaitingDoorAdd = new HashMap<>();
+    public final Map<UUID, Integer> awaitingDoorRemove = new HashMap<>();
+
     @Override
     public void onEnable() {
         if (!setupEconomy()) {
@@ -89,7 +92,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
 
     @EventHandler
     public void onSignChange(SignChangeEvent e) {
-        if (!e.getPlayer().hasPermission("mchouses.admin")) return;
+        if (!e.getPlayer().hasPermission("houses.admin")) return;
         String line0 = ChatColor.stripColor(e.getLine(0));
         if ("[House]".equalsIgnoreCase(line0)) {
             createHouseSign(e, false);
@@ -105,6 +108,10 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             price = Double.parseDouble(priceLine);
         } catch (Exception ex) {
             e.getPlayer().sendMessage(ChatColor.RED + "Invalid price");
+            return;
+        }
+        if (price <= 0) {
+            e.getPlayer().sendMessage(ChatColor.RED + "Price must be positive");
             return;
         }
         int id = housesConfig.getInt("lastId", 0) + 1;
@@ -131,12 +138,45 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         if (e.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         Block block = e.getClickedBlock();
         if (block == null) return;
+        Player p = e.getPlayer();
         Material type = block.getType();
+
+        // handle door additions or removals
+        if (isDoor(type)) {
+            UUID uid = p.getUniqueId();
+            if (awaitingDoorAdd.containsKey(uid)) {
+                int id = awaitingDoorAdd.remove(uid);
+                addDoorToHouse(id, block);
+                p.sendMessage(ChatColor.GREEN + "Door added to house " + id);
+                e.setCancelled(true);
+                return;
+            }
+            if (awaitingDoorRemove.containsKey(uid)) {
+                int id = awaitingDoorRemove.remove(uid);
+                removeDoorFromHouse(id, block);
+                p.sendMessage(ChatColor.GREEN + "Door removed from house " + id);
+                e.setCancelled(true);
+                return;
+            }
+
+            int doorHouse = getHouseIdByDoor(block);
+            if (doorHouse != -1) {
+                String owner = housesConfig.getString("houses." + doorHouse + ".owner");
+                if (owner != null && !owner.equals(uid.toString())) {
+                    p.sendMessage(ChatColor.RED + "You don't own this house.");
+                    e.setCancelled(true);
+                    return;
+                }
+            }
+        }
+
+        // sign interactions
         if (!(type == Material.OAK_SIGN || type == Material.OAK_WALL_SIGN || type == Material.SPRUCE_SIGN || type == Material.SPRUCE_WALL_SIGN ||
                 type == Material.BIRCH_SIGN || type == Material.BIRCH_WALL_SIGN || type == Material.JUNGLE_SIGN || type == Material.JUNGLE_WALL_SIGN ||
                 type == Material.ACACIA_SIGN || type == Material.ACACIA_WALL_SIGN || type == Material.DARK_OAK_SIGN || type == Material.DARK_OAK_WALL_SIGN)) {
             return;
         }
+
         Sign sign = (Sign) block.getState();
         String line0 = ChatColor.stripColor(sign.getLine(0));
         if (!line0.equalsIgnoreCase("[House]") && !line0.equalsIgnoreCase("[Rent]")) return;
@@ -152,11 +192,25 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         boolean rent = housesConfig.getBoolean(path + ".rent");
         double price = housesConfig.getDouble(path + ".price");
         String owner = housesConfig.getString(path + ".owner");
-        Player p = e.getPlayer();
 
         if (owner == null) {
             p.sendMessage(ChatColor.YELLOW + (rent ? "Rent" : "Buy") + " price: " + price);
             if (p.isSneaking()) {
+                int max = getConfig().getInt("max-houses-per-player", 0);
+                if (max > 0) {
+                    int owned = 0;
+                    if (housesConfig.isConfigurationSection("houses")) {
+                        for (String hid : housesConfig.getConfigurationSection("houses").getKeys(false)) {
+                            if (p.getUniqueId().toString().equals(housesConfig.getString("houses." + hid + ".owner"))) {
+                                owned++;
+                            }
+                        }
+                    }
+                    if (owned >= max) {
+                        p.sendMessage(ChatColor.RED + "You have reached the house limit of " + max);
+                        return;
+                    }
+                }
                 if (economy.getBalance(p) >= price) {
                     economy.withdrawPlayer(p, price);
                     housesConfig.set(path + ".owner", p.getUniqueId().toString());
@@ -187,4 +241,49 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             p.sendMessage(ChatColor.RED + "Someone else owns this.");
         }
     }
+
+    private boolean isDoor(Material m) {
+        return m.name().endsWith("_DOOR");
+    }
+
+    private String serialize(Block b) {
+        return b.getWorld().getName() + "," + b.getX() + "," + b.getY() + "," + b.getZ();
+    }
+
+    private void addDoorToHouse(int id, Block door) {
+        String path = "houses." + id + ".doors";
+        List<String> doors = housesConfig.getStringList(path);
+        String ser = serialize(door);
+        if (!doors.contains(ser)) {
+            doors.add(ser);
+            housesConfig.set(path, doors);
+            saveHouses();
+        }
+    }
+
+    private void removeDoorFromHouse(int id, Block door) {
+        String path = "houses." + id + ".doors";
+        List<String> doors = housesConfig.getStringList(path);
+        String ser = serialize(door);
+        if (doors.remove(ser)) {
+            housesConfig.set(path, doors);
+            saveHouses();
+        }
+    }
+
+    private int getHouseIdByDoor(Block b) {
+        if (!housesConfig.isConfigurationSection("houses")) return -1;
+        String ser = serialize(b);
+        for (String idStr : housesConfig.getConfigurationSection("houses").getKeys(false)) {
+            List<String> doors = housesConfig.getStringList("houses." + idStr + ".doors");
+            if (doors.contains(ser)) {
+                try {
+                    return Integer.parseInt(idStr);
+                } catch (NumberFormatException ignore) {
+                }
+            }
+        }
+        return -1;
+    }
+
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,5 +10,5 @@ commands:
 permissions:
   mchouses.use:
     default: true
-  mchouses.admin:
+  houses.admin:
     default: op


### PR DESCRIPTION
## Summary
- add `/houses adddoor <id>` for admins
- restrict sign creation and reload to `houses.admin`
- update README and plugin.yml permissions

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c321010ec83298dedb56d3f212109