### PR TITLE
Fix door lock when house unowned

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,9 @@ Commands:
 - `/houses owned` – list houses you own
 - `/houses adddoor <id>` – link a door to a house (admin, right-click the door after running the command)
 - `/houses reload` – reload configuration (admin only)
+- `/houses info <id>` – view details about a house
+- `/houses trust <id> <player>` – allow a player to open your doors
+- `/houses untrust <id> <player>` – revoke door access
+- `/houses market` – open a GUI with all houses
 
 Only the owner of a house can interact with its doors.

--- a/src/main/java/com/example/HousesCommand.java
+++ b/src/main/java/com/example/HousesCommand.java
@@ -5,7 +5,10 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
+import java.util.UUID;
 
 public class HousesCommand implements CommandExecutor {
     private final MinecraftHouses plugin;
@@ -54,6 +57,54 @@ public class HousesCommand implements CommandExecutor {
             }
             return true;
         }
+
+        if (args[0].equalsIgnoreCase("info")) {
+            if (args.length < 2) {
+                p.sendMessage(ChatColor.RED + "/houses info <id>");
+                return true;
+            }
+            int id;
+            try { id = Integer.parseInt(args[1]); } catch (NumberFormatException ex) { p.sendMessage(ChatColor.RED + "Invalid id"); return true; }
+            if (!cfg.isConfigurationSection("houses." + id)) { p.sendMessage(ChatColor.RED + "Unknown house"); return true; }
+            String path = "houses." + id;
+            boolean rent = cfg.getBoolean(path + ".rent");
+            double price = cfg.getDouble(path + ".price");
+            String owner = cfg.getString(path + ".owner");
+            p.sendMessage(ChatColor.GOLD + "House " + id);
+            p.sendMessage(ChatColor.YELLOW + "Price: " + price);
+            p.sendMessage(ChatColor.YELLOW + "Type: " + (rent ? "rent" : "buy"));
+            p.sendMessage(ChatColor.YELLOW + "Owner: " + (owner == null ? "none" : Bukkit.getOfflinePlayer(UUID.fromString(owner)).getName()));
+            p.sendMessage(ChatColor.YELLOW + "Doors: " + cfg.getStringList(path + ".doors").size());
+            p.sendMessage(ChatColor.YELLOW + "Trusted: " + String.join(", ", getTrustedNames(cfg.getStringList(path + ".trusted"))));
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("trust") || args[0].equalsIgnoreCase("untrust")) {
+            if (args.length < 3) {
+                p.sendMessage(ChatColor.RED + "/houses " + args[0].toLowerCase() + " <id> <player>");
+                return true;
+            }
+            int id;
+            try { id = Integer.parseInt(args[1]); } catch (NumberFormatException ex) { p.sendMessage(ChatColor.RED + "Invalid id"); return true; }
+            String path = "houses." + id;
+            if (!cfg.isConfigurationSection(path)) { p.sendMessage(ChatColor.RED + "Unknown house"); return true; }
+            String owner = cfg.getString(path + ".owner");
+            if (owner == null || !owner.equals(p.getUniqueId().toString())) { p.sendMessage(ChatColor.RED + "Not owner"); return true; }
+            OfflinePlayer target = Bukkit.getOfflinePlayer(args[2]);
+            if (args[0].equalsIgnoreCase("trust")) {
+                plugin.addTrusted(id, target.getUniqueId());
+                p.sendMessage(ChatColor.GREEN + "Trusted " + target.getName());
+            } else {
+                plugin.removeTrusted(id, target.getUniqueId());
+                p.sendMessage(ChatColor.GREEN + "Untrusted " + target.getName());
+            }
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("market")) {
+            plugin.openMarket(p, MinecraftHouses.MarketFilter.ALL);
+            return true;
+        }
         if (args[0].equalsIgnoreCase("adddoor")) {
             if (!p.hasPermission("houses.admin")) {
                 p.sendMessage(ChatColor.RED + "No permission");
@@ -94,9 +145,24 @@ public class HousesCommand implements CommandExecutor {
         p.sendMessage(ChatColor.YELLOW + "Available commands:");
         p.sendMessage(ChatColor.AQUA + "/houses list" + ChatColor.GRAY + " - list all houses");
         p.sendMessage(ChatColor.AQUA + "/houses owned" + ChatColor.GRAY + " - your houses");
+        p.sendMessage(ChatColor.AQUA + "/houses info <id>" + ChatColor.GRAY + " - house info");
+        p.sendMessage(ChatColor.AQUA + "/houses trust <id> <player>" + ChatColor.GRAY + " - trust player");
+        p.sendMessage(ChatColor.AQUA + "/houses untrust <id> <player>" + ChatColor.GRAY + " - untrust player");
+        p.sendMessage(ChatColor.AQUA + "/houses market" + ChatColor.GRAY + " - open market GUI");
         if (p.hasPermission("houses.admin")) {
             p.sendMessage(ChatColor.AQUA + "/houses adddoor <id>" + ChatColor.GRAY + " - add a door to a house");
             p.sendMessage(ChatColor.AQUA + "/houses reload" + ChatColor.GRAY + " - reload configs");
         }
+    }
+
+    private java.util.List<String> getTrustedNames(java.util.List<String> uuids) {
+        java.util.List<String> names = new java.util.ArrayList<>();
+        for (String u : uuids) {
+            try {
+                names.add(Bukkit.getOfflinePlayer(UUID.fromString(u)).getName());
+            } catch (Exception ignored) {
+            }
+        }
+        return names;
     }
 }

--- a/src/main/java/com/example/MinecraftHouses.java
+++ b/src/main/java/com/example/MinecraftHouses.java
@@ -4,15 +4,23 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Bisected;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import net.milkbowl.vault.economy.Economy;
@@ -28,6 +36,9 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
 
     public final Map<UUID, Integer> awaitingDoorAdd = new HashMap<>();
     public final Map<UUID, Integer> awaitingDoorRemove = new HashMap<>();
+
+    private enum MarketFilter { ALL, AVAILABLE, OWNED }
+    private final Map<UUID, MarketFilter> marketFilters = new HashMap<>();
 
     @Override
     public void onEnable() {
@@ -90,6 +101,14 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         return housesConfig;
     }
 
+    private void sendConfiguredMessage(Player player, String key, int id) {
+        String msg = getConfig().getString("messages." + key);
+        if (msg != null) {
+            msg = msg.replace("{id}", String.valueOf(id));
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', msg));
+        }
+    }
+
     @EventHandler
     public void onSignChange(SignChangeEvent e) {
         if (!e.getPlayer().hasPermission("houses.admin")) return;
@@ -133,7 +152,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         e.setLine(3, "id:" + id);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGH)
     public void onInteract(PlayerInteractEvent e) {
         if (e.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         Block block = e.getClickedBlock();
@@ -162,8 +181,9 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             int doorHouse = getHouseIdByDoor(block);
             if (doorHouse != -1) {
                 String owner = housesConfig.getString("houses." + doorHouse + ".owner");
-                if (owner != null && !owner.equals(uid.toString())) {
-                    p.sendMessage(ChatColor.RED + "You don't own this house.");
+                boolean trusted = isTrusted(doorHouse, uid);
+                if (owner == null || !(owner.equals(uid.toString()) || trusted)) {
+                    sendConfiguredMessage(p, "door-locked", doorHouse);
                     e.setCancelled(true);
                     return;
                 }
@@ -217,7 +237,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
                     saveHouses();
                     sign.setLine(2, p.getName());
                     sign.update();
-                    p.sendMessage(ChatColor.GREEN + (rent ? "Rented" : "Purchased") + " house " + id);
+                    sendConfiguredMessage(p, rent ? "rent-success" : "buy-success", id);
                 } else {
                     p.sendMessage(ChatColor.RED + "Not enough money");
                 }
@@ -233,7 +253,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
                 saveHouses();
                 sign.setLine(2, "");
                 sign.update();
-                p.sendMessage(ChatColor.GREEN + "Sold house " + id);
+                sendConfiguredMessage(p, rent ? "stop-rent-success" : "sell-success", id);
             } else {
                 p.sendMessage(ChatColor.GRAY + "Sneak and right click to confirm sale");
             }
@@ -271,12 +291,48 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         }
     }
 
+    private List<String> getTrusted(int id) {
+        return new ArrayList<>(housesConfig.getStringList("houses." + id + ".trusted"));
+    }
+
+    private boolean isTrusted(int id, UUID uuid) {
+        return getTrusted(id).contains(uuid.toString());
+    }
+
+    public void addTrusted(int id, UUID uuid) {
+        List<String> list = getTrusted(id);
+        String s = uuid.toString();
+        if (!list.contains(s)) {
+            list.add(s);
+            housesConfig.set("houses." + id + ".trusted", list);
+            saveHouses();
+        }
+    }
+
+    public void removeTrusted(int id, UUID uuid) {
+        List<String> list = getTrusted(id);
+        if (list.remove(uuid.toString())) {
+            housesConfig.set("houses." + id + ".trusted", list);
+            saveHouses();
+        }
+    }
+
     private int getHouseIdByDoor(Block b) {
         if (!housesConfig.isConfigurationSection("houses")) return -1;
-        String ser = serialize(b);
+        String serClicked = serialize(b);
+        // also check the other half of the door as players might click the top or bottom
+        String serOther = null;
+        BlockData data = b.getBlockData();
+        if (data instanceof Bisected) {
+            Bisected bisected = (Bisected) data;
+            Block other = bisected.getHalf() == Bisected.Half.TOP ? b.getRelative(BlockFace.DOWN)
+                    : b.getRelative(BlockFace.UP);
+            serOther = serialize(other);
+        }
+
         for (String idStr : housesConfig.getConfigurationSection("houses").getKeys(false)) {
             List<String> doors = housesConfig.getStringList("houses." + idStr + ".doors");
-            if (doors.contains(ser)) {
+            if (doors.contains(serClicked) || (serOther != null && doors.contains(serOther))) {
                 try {
                     return Integer.parseInt(idStr);
                 } catch (NumberFormatException ignore) {
@@ -284,6 +340,187 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             }
         }
         return -1;
+    }
+
+    private void updateHouseSign(int id, String ownerName) {
+        String path = "houses." + id + ".";
+        String world = housesConfig.getString(path + "world");
+        if (world == null) return;
+        Block b = Bukkit.getWorld(world).getBlockAt(
+                housesConfig.getInt(path + "x"),
+                housesConfig.getInt(path + "y"),
+                housesConfig.getInt(path + "z"));
+        if (b.getState() instanceof Sign) {
+            Sign sign = (Sign) b.getState();
+            sign.setLine(2, ownerName == null ? "" : ownerName);
+            sign.update();
+        }
+    }
+
+    private void buyHouse(Player p, int id) {
+        String path = "houses." + id;
+        boolean rent = housesConfig.getBoolean(path + ".rent");
+        double price = housesConfig.getDouble(path + ".price");
+
+        int max = getConfig().getInt("max-houses-per-player", 0);
+        if (max > 0) {
+            int owned = 0;
+            if (housesConfig.isConfigurationSection("houses")) {
+                for (String hid : housesConfig.getConfigurationSection("houses").getKeys(false)) {
+                    if (p.getUniqueId().toString().equals(housesConfig.getString("houses." + hid + ".owner"))) {
+                        owned++;
+                    }
+                }
+            }
+            if (owned >= max) {
+                p.sendMessage(ChatColor.RED + "You have reached the house limit of " + max);
+                return;
+            }
+        }
+
+        if (economy.getBalance(p) >= price) {
+            economy.withdrawPlayer(p, price);
+            housesConfig.set(path + ".owner", p.getUniqueId().toString());
+            housesConfig.set(path + ".trusted", new ArrayList<>());
+            saveHouses();
+            updateHouseSign(id, p.getName());
+            sendConfiguredMessage(p, rent ? "rent-success" : "buy-success", id);
+        } else {
+            p.sendMessage(ChatColor.RED + "Not enough money");
+        }
+    }
+
+    private void sellHouse(Player p, int id) {
+        String path = "houses." + id;
+        boolean rent = housesConfig.getBoolean(path + ".rent");
+        double price = housesConfig.getDouble(path + ".price");
+        double sellPrice = price * 0.75;
+        economy.depositPlayer(p, sellPrice);
+        housesConfig.set(path + ".owner", null);
+        housesConfig.set(path + ".trusted", new ArrayList<>());
+        saveHouses();
+        updateHouseSign(id, null);
+        sendConfiguredMessage(p, rent ? "stop-rent-success" : "sell-success", id);
+    }
+
+    public void openMarket(Player p, MarketFilter filter) {
+        marketFilters.put(p.getUniqueId(), filter);
+        Inventory inv = Bukkit.createInventory(null, 45, "House Market");
+
+        inv.setItem(0, createButton(Material.LIME_DYE, ChatColor.GREEN + "All"));
+        inv.setItem(1, createButton(Material.BLUE_DYE, ChatColor.BLUE + "Available"));
+        inv.setItem(2, createButton(Material.YELLOW_DYE, ChatColor.YELLOW + "Owned"));
+
+        List<Integer> ids = new ArrayList<>();
+        if (housesConfig.isConfigurationSection("houses")) {
+            for (String idStr : housesConfig.getConfigurationSection("houses").getKeys(false)) {
+                String owner = housesConfig.getString("houses." + idStr + ".owner");
+                int id = Integer.parseInt(idStr);
+                if (filter == MarketFilter.AVAILABLE && owner != null) continue;
+                if (filter == MarketFilter.OWNED && !p.getUniqueId().toString().equals(owner)) continue;
+                ids.add(id);
+            }
+        }
+
+        for (int i = 0; i < Math.min(27, ids.size()); i++) {
+            int id = ids.get(i);
+            String path = "houses." + id;
+            boolean rent = housesConfig.getBoolean(path + ".rent");
+            double price = housesConfig.getDouble(path + ".price");
+            ItemStack item = new ItemStack(rent ? Material.OAK_DOOR : Material.BRICKS);
+            ItemMeta meta = item.getItemMeta();
+            meta.setDisplayName(ChatColor.GOLD + "House #" + id);
+            meta.setLore(Arrays.asList(ChatColor.YELLOW + "Price: " + price,
+                    ChatColor.GRAY + (rent ? "Rent" : "Buy")));
+            item.setItemMeta(meta);
+            inv.setItem(9 + i, item);
+        }
+
+        p.openInventory(inv);
+    }
+
+    private ItemStack createButton(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    private void openHouseDetails(Player p, int id) {
+        Inventory inv = Bukkit.createInventory(null, 27, "House #" + id);
+        String path = "houses." + id;
+        boolean rent = housesConfig.getBoolean(path + ".rent");
+        double price = housesConfig.getDouble(path + ".price");
+        String owner = housesConfig.getString(path + ".owner");
+
+        ItemStack info = new ItemStack(Material.PAPER);
+        ItemMeta meta = info.getItemMeta();
+        meta.setDisplayName(ChatColor.GOLD + "House " + id);
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.YELLOW + "Price: " + price);
+        lore.add(ChatColor.GRAY + (rent ? "Rent" : "Buy"));
+        lore.add(ChatColor.GRAY + "Owner: " + (owner == null ? "none" : Bukkit.getOfflinePlayer(UUID.fromString(owner)).getName()));
+        meta.setLore(lore);
+        info.setItemMeta(meta);
+        inv.setItem(11, info);
+
+        ItemStack action = new ItemStack(Material.EMERALD_BLOCK);
+        ItemMeta aMeta = action.getItemMeta();
+        if (owner == null) {
+            aMeta.setDisplayName(ChatColor.GREEN + (rent ? "Rent" : "Buy"));
+        } else if (owner.equals(p.getUniqueId().toString())) {
+            aMeta.setDisplayName(ChatColor.GREEN + (rent ? "Stop Rent" : "Sell"));
+        } else {
+            aMeta.setDisplayName(ChatColor.RED + "Not yours");
+        }
+        action.setItemMeta(aMeta);
+        inv.setItem(15, action);
+
+        p.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent e) {
+        if (!(e.getWhoClicked() instanceof Player)) return;
+        Player p = (Player) e.getWhoClicked();
+        String title = e.getView().getTitle();
+        if (title.equals("House Market")) {
+            e.setCancelled(true);
+            int slot = e.getRawSlot();
+            if (slot == 0) { openMarket(p, MarketFilter.ALL); return; }
+            if (slot == 1) { openMarket(p, MarketFilter.AVAILABLE); return; }
+            if (slot == 2) { openMarket(p, MarketFilter.OWNED); return; }
+            if (slot >= 9 && slot < 36) {
+                ItemStack item = e.getCurrentItem();
+                if (item != null && item.hasItemMeta()) {
+                    String name = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+                    if (name.startsWith("House #")) {
+                        int id = Integer.parseInt(name.substring(7));
+                        openHouseDetails(p, id);
+                    }
+                }
+            }
+        } else if (title.startsWith("House #")) {
+            e.setCancelled(true);
+            int id = Integer.parseInt(title.substring(7));
+            String path = "houses." + id;
+            String owner = housesConfig.getString(path + ".owner");
+            ItemStack item = e.getCurrentItem();
+            if (item == null || !item.hasItemMeta()) return;
+            String name = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+            if (name.equalsIgnoreCase("Buy") || name.equalsIgnoreCase("Rent")) {
+                if (owner == null) {
+                    buyHouse(p, id);
+                    p.closeInventory();
+                }
+            } else if (name.equalsIgnoreCase("Sell") || name.equalsIgnoreCase("Stop Rent")) {
+                if (owner != null && owner.equals(p.getUniqueId().toString())) {
+                    sellHouse(p, id);
+                    p.closeInventory();
+                }
+            }
+        }
     }
 
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,3 +7,10 @@ database:
   user: root
   pass: password
   database: houses
+
+messages:
+  buy-success: "&aPurchased house {id}"
+  sell-success: "&aSold house {id}"
+  rent-success: "&aRented house {id}"
+  stop-rent-success: "&aStopped renting house {id}"
+  door-locked: "&cYou don't own this house"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,6 +7,7 @@ commands:
   houses:
     description: House commands
     permission: mchouses.use
+    aliases: [house]
 permissions:
   mchouses.use:
     default: true


### PR DESCRIPTION
## Summary
- block door interactions unless the interacting player owns the house
- admin commands require `houses.admin`
- add `/houses info <id>` to inspect houses
- allow owners to `/houses trust <id> <player>`
- inventory-based `/houses market` GUI

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_685c519725b88329ae90a60f1762d27f