### PR TITLE
Add multi-version support for Houses plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -203,9 +203,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         }
 
         // sign interactions
-        if (!(type == Material.OAK_SIGN || type == Material.OAK_WALL_SIGN || type == Material.SPRUCE_SIGN || type == Material.SPRUCE_WALL_SIGN ||
-                type == Material.BIRCH_SIGN || type == Material.BIRCH_WALL_SIGN || type == Material.JUNGLE_SIGN || type == Material.JUNGLE_WALL_SIGN ||
-                type == Material.ACACIA_SIGN || type == Material.ACACIA_WALL_SIGN || type == Material.DARK_OAK_SIGN || type == Material.DARK_OAK_WALL_SIGN)) {
+        if (!isSign(type)) {
             return;
         }
 
@@ -276,6 +274,11 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
 
     private boolean isDoor(Material m) {
         return m.name().endsWith("_DOOR");
+    }
+
+    private boolean isSign(Material m) {
+        String name = m.name();
+        return name.endsWith("_SIGN") || name.endsWith("_WALL_SIGN");
     }
 
     private String serialize(Block b) {


### PR DESCRIPTION
## Summary
- compile against Spigot API 1.21 snapshot
- detect sign materials generically for future versions

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685d55fae9d083299f018cb91d42a93d