### PR TITLE
Add bStats integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,13 @@
             <version>1.7</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- bStats Metrics -->
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>3.0.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -25,6 +25,7 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import net.milkbowl.vault.economy.Economy;
+import org.bstats.bukkit.Metrics;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,9 +57,10 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         saveDefaultConfig();
         getServer().getPluginManager().registerEvents(this, this);
         Objects.requireNonNull(getCommand("houses")).setExecutor(new HousesCommand(this));
-		getLogger().info("  ╭───────────────────────╮");
-		getLogger().info("  │      AlphaCTX's       │");
-		getLogger().info("  │        Houses         │");
+        new Metrics(this, 26286);
+                getLogger().info("  ╭───────────────────────╮");
+                getLogger().info("  │      AlphaCTX's       │");
+                getLogger().info("  │        Houses         │");
 		getLogger().info("  │         Plugin        │");
 		getLogger().info("  ╰───────────────────────╯");
 		getLogger().info("        Houses Enabled!");


### PR DESCRIPTION
## Summary
- add bStats dependency
- start Metrics in the plugin

## Testing
- `mvn package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin from https://repo.maven.apache.org because Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685d8e8d37508329bd177e9cfae92f2a