### PR TITLE
Add online rent check and inactivity cleanup

### DIFF
--- a/src/main/java/com/alphactx/HousesCommand.java
+++ b/src/main/java/com/alphactx/HousesCommand.java
@@ -64,6 +64,33 @@ public class HousesCommand implements TabExecutor {
             return true;
         }
 
+        if (args[0].equalsIgnoreCase("checkrent")) {
+            long now = System.currentTimeMillis();
+            boolean any = false;
+            if (cfg.isConfigurationSection("houses")) {
+                for (String id : cfg.getConfigurationSection("houses").getKeys(false)) {
+                    String path = "houses." + id;
+                    if (!cfg.getBoolean(path + ".rent")) continue;
+                    if (!p.getUniqueId().toString().equals(cfg.getString(path + ".owner"))) continue;
+                    long next = cfg.getLong(path + ".nextRent", 0L);
+                    long diff = next - now;
+                    if (next == 0L || diff <= 0) {
+                        p.sendMessage(ChatColor.YELLOW + "[Houses]" + ChatColor.RED + " Rent overdue for house " + id);
+                    } else {
+                        long sec = diff / 1000;
+                        long min = sec / 60;
+                        sec %= 60;
+                        p.sendMessage(ChatColor.YELLOW + "[Houses]" + ChatColor.GREEN + "House " + id + " next rent in " + min + "m" + sec + "s");
+                    }
+                    any = true;
+                }
+            }
+            if (!any) {
+                p.sendMessage(ChatColor.YELLOW + "[Houses]" + ChatColor.GRAY + " No rented houses");
+            }
+            return true;
+        }
+
         if (args[0].equalsIgnoreCase("info")) {
             if (args.length < 2) {
                 p.sendMessage(ChatColor.RED + "/houses info <id>");
@@ -227,7 +254,7 @@ public class HousesCommand implements TabExecutor {
     @Override
     public java.util.List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
-            java.util.List<String> subs = java.util.Arrays.asList("list","owned","info","trust","untrust","market","wand","adddoor","removedoor","reload","changeprice","backup");
+            java.util.List<String> subs = java.util.Arrays.asList("list","owned","info","trust","untrust","market","checkrent","wand","adddoor","removedoor","reload","changeprice","backup");
             if (sender.hasPermission("houses.admin")) {
                 // all available already include admin ones
             } else {
@@ -246,6 +273,7 @@ public class HousesCommand implements TabExecutor {
         p.sendMessage(ChatColor.AQUA + "/houses trust <id> <player>" + ChatColor.GRAY + " - trust player");
         p.sendMessage(ChatColor.AQUA + "/houses untrust <id> <player>" + ChatColor.GRAY + " - untrust player");
         p.sendMessage(ChatColor.AQUA + "/houses market" + ChatColor.GRAY + " - open market GUI");
+        p.sendMessage(ChatColor.AQUA + "/houses checkrent" + ChatColor.GRAY + " - time until next rent");
         if (p.hasPermission("houses.admin")) {
             p.sendMessage(ChatColor.AQUA + "/houses wand" + ChatColor.GRAY + " - get a house wand");
             p.sendMessage(ChatColor.AQUA + "/houses adddoor <id>" + ChatColor.GRAY + " - add a door to a house");

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -53,6 +53,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     private final Map<UUID, org.bukkit.Location> teleportLocations = new HashMap<>();
     public final Map<UUID, Integer> wandSelections = new HashMap<>();
     private int rentTask = -1;
+    private int cleanupTask = -1;
 
     private boolean useMysql() {
         return getConfig().getBoolean("database.use-mysql", false);
@@ -74,6 +75,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(this, this);
         Objects.requireNonNull(getCommand("houses")).setExecutor(new HousesCommand(this));
         startRentTask();
+        startCleanupTask();
         new Metrics(this, 26286);
                 getLogger().info("  ╭───────────────────────╮");
                 getLogger().info("  │      AlphaCTX's       │");
@@ -88,6 +90,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         saveHousesSync();
         stopAutoSave();
         stopRentTask();
+        stopCleanupTask();
         closeDatabase();
                 getLogger().info("Houses Disabled!");
     }
@@ -213,6 +216,12 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         rentTask = getServer().getScheduler().runTaskTimer(this, this::checkRentPayments, interval * 20L, interval * 20L).getTaskId();
     }
 
+    private void startCleanupTask() {
+        int interval = getConfig().getInt("cleanup.check-interval", 86400);
+        if (interval <= 0) return;
+        cleanupTask = getServer().getScheduler().runTaskTimer(this, this::checkInactiveOwners, interval * 20L, interval * 20L).getTaskId();
+    }
+
     private void stopRentTask() {
         if (rentTask != -1) {
             getServer().getScheduler().cancelTask(rentTask);
@@ -220,8 +229,19 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         }
     }
 
+    private void stopCleanupTask() {
+        if (cleanupTask != -1) {
+            getServer().getScheduler().cancelTask(cleanupTask);
+            cleanupTask = -1;
+        }
+    }
+
     private void checkRentPayments() {
-        long period = getConfig().getLong("rent.period", 86400) * 1000L;
+        checkRentPayments(null);
+    }
+
+    private void checkRentPayments(UUID only) {
+        long period = getConfig().getLong("rent.period", 2400) * 1000L;
         long now = System.currentTimeMillis();
         if (housesConfig.isConfigurationSection("houses")) {
             for (String idStr : housesConfig.getConfigurationSection("houses").getKeys(false)) {
@@ -229,25 +249,50 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
                 if (!housesConfig.getBoolean(path + ".rent")) continue;
                 String owner = housesConfig.getString(path + ".owner");
                 if (owner == null) continue;
+                if (only != null && !owner.equals(only.toString())) continue;
                 long next = housesConfig.getLong(path + ".nextRent", 0L);
                 if (now >= next) {
                     OfflinePlayer op = Bukkit.getOfflinePlayer(UUID.fromString(owner));
+                    if (!op.isOnline()) continue;
                     double price = housesConfig.getDouble(path + ".price");
                     if (economy.has(op, price)) {
                         economy.withdrawPlayer(op, price);
                         housesConfig.set(path + ".nextRent", now + period);
-                        if (op.isOnline()) op.getPlayer().sendMessage(ChatColor.YELLOW + "[Houses]" + ChatColor.GREEN + "Rent for house " + idStr + " paid");
+                        sendConfiguredMessage(op.getPlayer(), "rent-paid", Integer.parseInt(idStr));
                     } else {
                         housesConfig.set(path + ".owner", null);
                         housesConfig.set(path + ".trusted", new ArrayList<>());
                         housesConfig.set(path + ".nextRent", null);
                         updateHouseSign(Integer.parseInt(idStr), null);
-                        if (op.isOnline()) op.getPlayer().sendMessage(ChatColor.YELLOW + "[Houses]" + ChatColor.RED + "Rent unpaid, house " + idStr + " lost");
+                        sendConfiguredMessage(op.getPlayer(), "rent-stopped", Integer.parseInt(idStr));
                     }
+                }
+        }
+        saveHouses();
+    }
+
+    private void checkInactiveOwners() {
+        int days = getConfig().getInt("cleanup.inactive-days", 30);
+        long limit = System.currentTimeMillis() - days * 86400000L;
+        if (housesConfig.isConfigurationSection("houses")) {
+            for (String idStr : housesConfig.getConfigurationSection("houses").getKeys(false)) {
+                String path = "houses." + idStr;
+                String owner = housesConfig.getString(path + ".owner");
+                if (owner == null) continue;
+                OfflinePlayer op = Bukkit.getOfflinePlayer(UUID.fromString(owner));
+                if (op.isOnline()) continue;
+                if (op.getLastPlayed() >= limit) continue;
+                housesConfig.set(path + ".owner", null);
+                housesConfig.set(path + ".trusted", new ArrayList<>());
+                housesConfig.set(path + ".nextRent", null);
+                updateHouseSign(Integer.parseInt(idStr), null);
+                if (op.isOnline()) {
+                    sendConfiguredMessage(op.getPlayer(), "inactive-removed", Integer.parseInt(idStr));
                 }
             }
             saveHouses();
         }
+    }
     }
 
     private void loadHousesFromDatabase() {
@@ -650,7 +695,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             housesConfig.set(path + ".owner", p.getUniqueId().toString());
             housesConfig.set(path + ".trusted", new ArrayList<>());
             if (rent) {
-                long period = getConfig().getLong("rent.period", 86400) * 1000L;
+                long period = getConfig().getLong("rent.period", 2400) * 1000L;
                 housesConfig.set(path + ".nextRent", System.currentTimeMillis() + period);
             }
             saveHouses();
@@ -895,6 +940,12 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
                 cancelTeleport(p);
             }
         }
+    }
+
+    @EventHandler
+    public void onJoin(org.bukkit.event.player.PlayerJoinEvent e) {
+        UUID uid = e.getPlayer().getUniqueId();
+        Bukkit.getScheduler().runTaskLater(this, () -> checkRentPayments(uid), 20L);
     }
 
     private void cancelTeleport(Player p) {

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -293,7 +293,6 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             saveHouses();
         }
     }
-    }
 
     private void loadHousesFromDatabase() {
         loadHousesFromConnection(sqlConnection);

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -267,8 +267,9 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
                         sendConfiguredMessage(op.getPlayer(), "rent-stopped", Integer.parseInt(idStr));
                     }
                 }
+            }
+            saveHouses();
         }
-        saveHouses();
     }
 
     private void checkInactiveOwners() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,8 +27,12 @@ database:
 #=============================
 teleport-wait: 5
 rent:
-  period: 86400 # seconds
+  period: 2400 # seconds (2 Minecraft days)
   check-interval: 600 # seconds
+
+cleanup:
+  check-interval: 86400 # seconds
+  inactive-days: 30
 
 #===========================
 #=     CUSTOM MESSAGES     =
@@ -39,3 +43,6 @@ messages:
   rent-success: "&aRented house {id}"
   stop-rent-success: "&aStopped renting house {id}"
   door-locked: "&cYou don't own this house"
+  rent-paid: "&aRent for house {id} paid"
+  rent-stopped: "&cRent unpaid, house {id} lost"
+  inactive-removed: "&cHouse {id} removed due to inactivity"


### PR DESCRIPTION
## Summary
- adjust rent period to 2 Minecraft days
- send configurable rent payment/stop messages
- only charge rent when owner is online
- add `/houses checkrent` command
- automatically remove houses from inactive players

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cdca4f288329856860b338383c72