### PR TITLE
Add PlaceholderAPI and permission checks

### DIFF
--- a/pom-1.16.xml
+++ b/pom-1.16.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>de.bluecolored</groupId>
             <artifactId>bluemap-api</artifactId>
-            <version>2.7.4</version>
+            <version>2.7.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom-1.16.xml
+++ b/pom-1.16.xml
@@ -44,6 +44,14 @@
             <version>3.0.2</version>
         </dependency>
 
+        <!-- PlaceholderAPI for placeholders -->
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- MySQL Connector (in je JAR of server-classpath) -->
         <dependency>
             <groupId>mysql</groupId>

--- a/pom-1.16.xml
+++ b/pom-1.16.xml
@@ -22,6 +22,7 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <!-- BlueColored Releases voor BlueMapAPI -->
         <repository>
             <id>bluecolored</id>
             <url>https://repo.bluecolored.de/releases</url>
@@ -52,7 +53,7 @@
             <version>3.0.2</version>
         </dependency>
 
-        <!-- PlaceholderAPI for placeholders -->
+        <!-- PlaceholderAPI voor placeholders -->
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
@@ -60,13 +61,22 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- BlueMap API for map markers -->
+        <!-- BlueMap API voor map markers (upgrade naar 2.7.2) -->
         <dependency>
-            <groupId>de.bluecolored</groupId>
-            <artifactId>bluemap-api</artifactId>
+            <groupId>de.bluecolored.bluemap</groupId>
+            <artifactId>BlueMapAPI</artifactId>
+            <version>2.7.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- alternatief: als je per se 2.7.0 wilt, via Jitpack -->
+        <!--
+        <dependency>
+            <groupId>com.github.BlueMap-Minecraft</groupId>
+            <artifactId>BlueMapAPI</artifactId>
             <version>2.7.0</version>
             <scope>provided</scope>
         </dependency>
+        -->
 
         <!-- MySQL Connector (in je JAR of server-classpath) -->
         <dependency>
@@ -74,7 +84,7 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.33</version>
         </dependency>
-        <!-- SQLite driver for local storage -->
+        <!-- SQLite driver voor lokale opslag -->
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
@@ -107,14 +117,12 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <!-- Relocate bStats naar een eigen package -->
                             <relocations>
                                 <relocation>
                                     <pattern>org.bstats</pattern>
                                     <shadedPattern>com.alphactx.shaded.org.bstats</shadedPattern>
                                 </relocation>
                             </relocations>
-                            <!-- Zorg dat provided-deps niet gebundeld worden -->
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.spigotmc:spigot-api</exclude>

--- a/pom-1.16.xml
+++ b/pom-1.16.xml
@@ -22,6 +22,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>bluecolored</id>
+            <url>https://repo.bluecolored.de/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -53,6 +57,14 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- BlueMap API for map markers -->
+        <dependency>
+            <groupId>de.bluecolored</groupId>
+            <artifactId>bluemap-api</artifactId>
+            <version>2.7.4</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom-1.16.xml
+++ b/pom-1.16.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alphactx</groupId>
     <artifactId>Houses</artifactId>
-    <version>1.1.7-mc1.16</version>
+    <version>1.2.1-mc1.16</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -17,6 +17,10 @@
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
+        </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
     </repositories>
 

--- a/pom-1.21.xml
+++ b/pom-1.21.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alphactx</groupId>
     <artifactId>Houses</artifactId>
-    <version>1.1.7-mc1.21</version>
+    <version>1.2.1-mc1.21</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -19,6 +19,10 @@
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
+        </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
     </repositories>
 

--- a/pom-1.21.xml
+++ b/pom-1.21.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>de.bluecolored</groupId>
             <artifactId>bluemap-api</artifactId>
-            <version>2.7.4</version>
+            <version>2.7.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom-1.21.xml
+++ b/pom-1.21.xml
@@ -46,6 +46,14 @@
             <version>3.0.2</version>
         </dependency>
 
+        <!-- PlaceholderAPI for placeholders -->
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- MySQL Connector (één van beide: bundelen óf op server-classpath) -->
         <dependency>
             <groupId>mysql</groupId>

--- a/pom-1.21.xml
+++ b/pom-1.21.xml
@@ -24,6 +24,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>bluecolored</id>
+            <url>https://repo.bluecolored.de/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -55,6 +59,14 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- BlueMap API for map markers -->
+        <dependency>
+            <groupId>de.bluecolored</groupId>
+            <artifactId>bluemap-api</artifactId>
+            <version>2.7.4</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom-1.21.xml
+++ b/pom-1.21.xml
@@ -1,8 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
+<project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alphactx</groupId>
     <artifactId>Houses</artifactId>
@@ -10,12 +10,10 @@
     <packaging>jar</packaging>
 
     <repositories>
-        <!-- Spigot snapshot repository -->
         <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
-        <!-- JitPack (voor Vault of andere libs indien nodig) -->
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
@@ -31,7 +29,7 @@
     </repositories>
 
     <dependencies>
-        <!-- Spigot API 1.21 (provided zodat het niet in je JAR komt) -->
+        <!-- Spigot API 1.21 (provided) -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
@@ -39,7 +37,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Vault API (provided, door server geleverd) -->
+        <!-- Vault API (provided) -->
         <dependency>
             <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
@@ -47,14 +45,14 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- bStats Metrics (wordt geshaded voor mee-insluiten) -->
+        <!-- bStats Metrics (wordt geshaded) -->
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>3.0.2</version>
         </dependency>
 
-        <!-- PlaceholderAPI for placeholders -->
+        <!-- PlaceholderAPI (provided) -->
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
@@ -62,21 +60,22 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- BlueMap API for map markers -->
+        <!-- BlueMap API (upgrade naar 2.7.2, correct groupId/artifactId) -->
         <dependency>
-            <groupId>de.bluecolored</groupId>
-            <artifactId>bluemap-api</artifactId>
-            <version>2.7.0</version>
+            <groupId>de.bluecolored.bluemap</groupId>
+            <artifactId>BlueMapAPI</artifactId>
+            <version>2.7.2</version>
             <scope>provided</scope>
         </dependency>
 
-        <!-- MySQL Connector (één van beide: bundelen óf op server-classpath) -->
+        <!-- MySQL Connector -->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.33</version>
         </dependency>
-        <!-- SQLite driver for local storage -->
+
+        <!-- SQLite JDBC Driver -->
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
@@ -86,7 +85,7 @@
 
     <build>
         <plugins>
-            <!-- Java-compiler instellen -->
+            <!-- Compiler plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -97,7 +96,7 @@
                 </configuration>
             </plugin>
 
-            <!-- Shade-plugin: alleen bStats relokeren, Spigot & Vault uitsluiten -->
+            <!-- Shade-plugin: relocaliseer bStats, sluit provided-deps uit -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -109,14 +108,12 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <!-- Relocate alleen bStats naar eigen package -->
                             <relocations>
                                 <relocation>
                                     <pattern>org.bstats</pattern>
                                     <shadedPattern>com.alphactx.shaded.org.bstats</shadedPattern>
                                 </relocation>
                             </relocations>
-                            <!-- voorkom bundeling van provided-deps -->
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.spigotmc:spigot-api</exclude>

--- a/src/main/java/com/alphactx/HousesCommand.java
+++ b/src/main/java/com/alphactx/HousesCommand.java
@@ -30,6 +30,10 @@ public class HousesCommand implements TabExecutor {
             return true;
         }
         Player p = (Player) sender;
+        if (!p.hasPermission("houses.use") && !p.hasPermission("houses.admin")) {
+            p.sendMessage(ChatColor.YELLOW + "[Houses]" + ChatColor.RED + "No permission");
+            return true;
+        }
         FileConfiguration cfg = plugin.getHousesConfig();
         if (args.length == 0 || args[0].equalsIgnoreCase("help")) {
             sendHelp(p);

--- a/src/main/java/com/alphactx/HousesPlaceholder.java
+++ b/src/main/java/com/alphactx/HousesPlaceholder.java
@@ -1,0 +1,86 @@
+package com.alphactx;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
+/**
+ * PlaceholderAPI expansion for the Houses plugin.
+ */
+public class HousesPlaceholder extends PlaceholderExpansion {
+
+    private final MinecraftHouses plugin;
+
+    public HousesPlaceholder(MinecraftHouses plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public boolean canRegister() {
+        return true;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "houses";
+    }
+
+    @Override
+    public String getAuthor() {
+        return String.join(",", plugin.getDescription().getAuthors());
+    }
+
+    @Override
+    public String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String identifier) {
+        if (player == null) return "";
+        if (identifier.equalsIgnoreCase("owned")) {
+            return String.valueOf(countOwned(player));
+        }
+        if (identifier.equalsIgnoreCase("limit")) {
+            return String.valueOf(plugin.getConfig().getInt("max-houses-per-player", 0));
+        }
+        if (identifier.equalsIgnoreCase("renting")) {
+            return String.valueOf(countRenting(player));
+        }
+        return null;
+    }
+
+    private int countOwned(Player p) {
+        int owned = 0;
+        FileConfiguration cfg = plugin.getHousesConfig();
+        if (cfg.isConfigurationSection("houses")) {
+            for (String id : cfg.getConfigurationSection("houses").getKeys(false)) {
+                String owner = cfg.getString("houses." + id + ".owner");
+                if (owner != null && owner.equals(p.getUniqueId().toString())) {
+                    owned++;
+                }
+            }
+        }
+        return owned;
+    }
+
+    private int countRenting(Player p) {
+        int renting = 0;
+        FileConfiguration cfg = plugin.getHousesConfig();
+        if (cfg.isConfigurationSection("houses")) {
+            for (String id : cfg.getConfigurationSection("houses").getKeys(false)) {
+                String path = "houses." + id;
+                String owner = cfg.getString(path + ".owner");
+                if (owner != null && owner.equals(p.getUniqueId().toString()) && cfg.getBoolean(path + ".rent")) {
+                    renting++;
+                }
+            }
+        }
+        return renting;
+    }
+}

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -28,7 +28,7 @@ import org.bukkit.plugin.RegisteredServiceProvider;
 import net.milkbowl.vault.economy.Economy;
 import org.bstats.bukkit.Metrics;
 import de.bluecolored.bluemap.api.BlueMapAPI;
-import de.bluecolored.bluemap.api.map.BlueMapMap;
+import de.bluecolored.bluemap.api.BlueMapMap;
 import de.bluecolored.bluemap.api.markers.MarkerSet;
 import de.bluecolored.bluemap.api.markers.POIMarker;
 import com.flowpowered.math.vector.Vector3d;

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -60,6 +60,8 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     private Object dynmapMarkerAPI;
     private Object dynmapMarkerSet;
     private final java.util.List<Object> bluemapSets = new java.util.ArrayList<>();
+    private Object bluemapEnableListener;
+    private Object bluemapDisableListener;
 
     private boolean useMysql() {
         return getConfig().getBoolean("database.use-mysql", false);
@@ -272,6 +274,17 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             removeAllBlueMapMarkers();
             bluemapSets.clear();
         }
+        if (bluemapEnableListener != null) {
+            try {
+                Class<?> apiClass = Class.forName("de.bluecolored.bluemap.api.BlueMapAPI");
+                Class<?> consumerClass = Class.forName("java.util.function.Consumer");
+                java.lang.reflect.Method unregister = apiClass.getMethod("unregisterListener", consumerClass);
+                unregister.invoke(null, bluemapEnableListener);
+                unregister.invoke(null, bluemapDisableListener);
+            } catch (Exception ignored) {}
+            bluemapEnableListener = null;
+            bluemapDisableListener = null;
+        }
     }
 
     private void initDynmap() {
@@ -298,28 +311,63 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     private void initBlueMap() {
         try {
             Class<?> apiClass = Class.forName("de.bluecolored.bluemap.api.BlueMapAPI");
+            Class<?> consumerClass = Class.forName("java.util.function.Consumer");
+            java.lang.reflect.Method onEnable = apiClass.getMethod("onEnable", consumerClass);
+            java.lang.reflect.Method onDisable = apiClass.getMethod("onDisable", consumerClass);
+
+            bluemapEnableListener = java.lang.reflect.Proxy.newProxyInstance(
+                    consumerClass.getClassLoader(), new Class[]{consumerClass},
+                    (proxy, method, args) -> {
+                        if ("accept".equals(method.getName())) {
+                            setupBlueMap(args[0]);
+                            updateAllBlueMapMarkers();
+                        }
+                        return null;
+                    });
+
+            bluemapDisableListener = java.lang.reflect.Proxy.newProxyInstance(
+                    consumerClass.getClassLoader(), new Class[]{consumerClass},
+                    (proxy, method, args) -> {
+                        if ("accept".equals(method.getName())) {
+                            removeAllBlueMapMarkers();
+                            bluemapSets.clear();
+                        }
+                        return null;
+                    });
+
+            onEnable.invoke(null, bluemapEnableListener);
+            onDisable.invoke(null, bluemapDisableListener);
+
             java.util.Optional<?> opt = (java.util.Optional<?>) apiClass.getMethod("getInstance").invoke(null);
-            if (!((Boolean) opt.getClass().getMethod("isPresent").invoke(opt))) return;
-            Object api = opt.getClass().getMethod("get").invoke(opt);
-            java.util.Collection<?> maps = (java.util.Collection<?>) apiClass.getMethod("getMaps").invoke(api);
-            Class<?> markerSetClass = Class.forName("de.bluecolored.bluemap.api.markers.MarkerSet");
-            for (Object map : maps) {
-                java.util.Map<?,?> sets = (java.util.Map<?,?>) map.getClass().getMethod("getMarkerSets").invoke(map);
-                Object set = sets.get("houses");
-                if (set == null) {
-                    Object builder = markerSetClass.getMethod("builder").invoke(null);
-                    builder.getClass().getMethod("label", String.class).invoke(builder, "Houses");
-                    builder.getClass().getMethod("toggleable", Boolean.class).invoke(builder, true);
-                    set = builder.getClass().getMethod("build").invoke(builder);
-                    sets.put("houses", set);
-                }
-                bluemapSets.add(set);
+            if (((Boolean) opt.getClass().getMethod("isPresent").invoke(opt))) {
+                Object api = opt.getClass().getMethod("get").invoke(opt);
+                setupBlueMap(api);
+                updateAllBlueMapMarkers();
             }
+
         } catch (Exception ex) {
             getLogger().warning("BlueMap hook failed: " + ex.getMessage());
             bluemapSets.clear();
         }
-        updateAllBlueMapMarkers();
+    }
+
+    private void setupBlueMap(Object api) throws Exception {
+        bluemapSets.clear();
+        java.util.Collection<?> maps = (java.util.Collection<?>) api.getClass().getMethod("getMaps").invoke(api);
+        Class<?> markerSetClass = Class.forName("de.bluecolored.bluemap.api.markers.MarkerSet");
+        for (Object map : maps) {
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, Object> sets = (java.util.Map<String, Object>) map.getClass().getMethod("getMarkerSets").invoke(map);
+            Object set = sets.get("houses");
+            if (set == null) {
+                Object builder = markerSetClass.getMethod("builder").invoke(null);
+                builder.getClass().getMethod("label", String.class).invoke(builder, "Houses");
+                builder.getClass().getMethod("toggleable", Boolean.class).invoke(builder, true);
+                set = builder.getClass().getMethod("build").invoke(builder);
+                sets.put("houses", set);
+            }
+            bluemapSets.add(set);
+        }
     }
 
     private void updateMapMarkers(int id) {

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -27,6 +27,11 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import net.milkbowl.vault.economy.Economy;
 import org.bstats.bukkit.Metrics;
+import de.bluecolored.bluemap.api.BlueMapAPI;
+import de.bluecolored.bluemap.api.map.BlueMapMap;
+import de.bluecolored.bluemap.api.markers.MarkerSet;
+import de.bluecolored.bluemap.api.markers.POIMarker;
+import com.flowpowered.math.vector.Vector3d;
 
 import java.io.File;
 import java.util.*;
@@ -59,10 +64,9 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     private boolean bluemapEnabled;
     private Object dynmapMarkerAPI;
     private Object dynmapMarkerSet;
-    private final java.util.List<Object> bluemapSets = new java.util.ArrayList<>();
-    private Object bluemapEnableListener;
-    private Object bluemapDisableListener;
-    private ClassLoader bluemapLoader;
+    private final java.util.List<MarkerSet> bluemapSets = new java.util.ArrayList<>();
+    private java.util.function.Consumer<BlueMapAPI> bluemapEnableListener;
+    private java.util.function.Consumer<BlueMapAPI> bluemapDisableListener;
 
     private boolean useMysql() {
         return getConfig().getBoolean("database.use-mysql", false);
@@ -276,16 +280,10 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             bluemapSets.clear();
         }
         if (bluemapEnableListener != null) {
-            try {
-                Class<?> apiClass = Class.forName("de.bluecolored.bluemap.api.BlueMapAPI");
-                Class<?> consumerClass = Class.forName("java.util.function.Consumer");
-                java.lang.reflect.Method unregister = apiClass.getMethod("unregisterListener", consumerClass);
-                unregister.invoke(null, bluemapEnableListener);
-                unregister.invoke(null, bluemapDisableListener);
-            } catch (Exception ignored) {}
+            BlueMapAPI.unregisterListener(bluemapEnableListener);
+            BlueMapAPI.unregisterListener(bluemapDisableListener);
             bluemapEnableListener = null;
             bluemapDisableListener = null;
-            bluemapLoader = null;
         }
     }
 
@@ -311,68 +309,29 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     }
 
     private void initBlueMap() {
-        try {
-            org.bukkit.plugin.Plugin bm = getServer().getPluginManager().getPlugin("BlueMap");
-            if (bm == null) return;
-            bluemapLoader = bm.getClass().getClassLoader();
-
-            Class<?> apiClass = Class.forName("de.bluecolored.bluemap.api.BlueMapAPI", true, bluemapLoader);
-            Class<?> consumerClass = Class.forName("java.util.function.Consumer");
-            java.lang.reflect.Method onEnable = apiClass.getMethod("onEnable", consumerClass);
-            java.lang.reflect.Method onDisable = apiClass.getMethod("onDisable", consumerClass);
-
-            ClassLoader loader = getClass().getClassLoader();
-
-            bluemapEnableListener = java.lang.reflect.Proxy.newProxyInstance(
-                    loader, new Class[]{consumerClass},
-                    (proxy, method, args) -> {
-                        if ("accept".equals(method.getName())) {
-                            setupBlueMap(args[0]);
-                            updateAllBlueMapMarkers();
-                        }
-                        return null;
-                    });
-
-            bluemapDisableListener = java.lang.reflect.Proxy.newProxyInstance(
-                    loader, new Class[]{consumerClass},
-                    (proxy, method, args) -> {
-                        if ("accept".equals(method.getName())) {
-                            removeAllBlueMapMarkers();
-                            bluemapSets.clear();
-                        }
-                        return null;
-                    });
-
-            onEnable.invoke(null, bluemapEnableListener);
-            onDisable.invoke(null, bluemapDisableListener);
-
-            java.util.Optional<?> opt = (java.util.Optional<?>) apiClass.getMethod("getInstance").invoke(null);
-            if (((Boolean) opt.getClass().getMethod("isPresent").invoke(opt))) {
-                Object api = opt.getClass().getMethod("get").invoke(opt);
-                setupBlueMap(api);
-                updateAllBlueMapMarkers();
-            }
-
-        } catch (Exception ex) {
-            getLogger().warning("BlueMap hook failed: " + ex.getMessage());
+        bluemapEnableListener = api -> {
+            setupBlueMap(api);
+            updateAllBlueMapMarkers();
+        };
+        bluemapDisableListener = api -> {
+            removeAllBlueMapMarkers();
             bluemapSets.clear();
-        }
+        };
+        BlueMapAPI.onEnable(bluemapEnableListener);
+        BlueMapAPI.onDisable(bluemapDisableListener);
+        BlueMapAPI.getInstance().ifPresent(bluemapEnableListener);
     }
 
-    private void setupBlueMap(Object api) throws Exception {
+    private void setupBlueMap(BlueMapAPI api) {
         bluemapSets.clear();
-        java.util.Collection<?> maps = (java.util.Collection<?>) api.getClass().getMethod("getMaps").invoke(api);
-        Class<?> markerSetClass = Class.forName("de.bluecolored.bluemap.api.markers.MarkerSet", true, bluemapLoader);
-        for (Object map : maps) {
-            @SuppressWarnings("unchecked")
-            java.util.Map<String, Object> sets = (java.util.Map<String, Object>) map.getClass().getMethod("getMarkerSets").invoke(map);
-            Object set = sets.get("houses");
+        for (BlueMapMap map : api.getMaps()) {
+            MarkerSet set = map.getMarkerSets().get("houses");
             if (set == null) {
-                Object builder = markerSetClass.getMethod("builder").invoke(null);
-                builder.getClass().getMethod("label", String.class).invoke(builder, "Houses");
-                builder.getClass().getMethod("toggleable", Boolean.class).invoke(builder, true);
-                set = builder.getClass().getMethod("build").invoke(builder);
-                sets.put("houses", set);
+                set = MarkerSet.builder()
+                        .label("Houses")
+                        .toggleable(true)
+                        .build();
+                map.getMarkerSets().put("houses", set);
             }
             bluemapSets.add(set);
         }
@@ -407,12 +366,9 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     }
 
     private void removeAllBlueMapMarkers() {
-        try {
-            for (Object set : bluemapSets) {
-                java.util.Map<?,?> markers = (java.util.Map<?,?>) set.getClass().getMethod("getMarkers").invoke(set);
-                markers.clear();
-            }
-        } catch (Exception ignored) {}
+        for (MarkerSet set : bluemapSets) {
+            set.getMarkers().clear();
+        }
     }
 
     private void updateAllDynmapMarkers() {
@@ -468,45 +424,41 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
 
     private void updateBlueMapMarker(int id) {
         if (bluemapSets.isEmpty()) return;
-        try {
-            String path = "houses." + id;
-            int x = housesConfig.getInt(path + ".x");
-            int y = housesConfig.getInt(path + ".y");
-            int z = housesConfig.getInt(path + ".z");
-            boolean rent = housesConfig.getBoolean(path + ".rent");
-            double price = housesConfig.getDouble(path + ".price");
-            String owner = housesConfig.getString(path + ".owner");
-            String ownerName = owner == null ? null : Bukkit.getOfflinePlayer(java.util.UUID.fromString(owner)).getName();
-            String label = (rent ? "[Rent] " : "[Buy] ") + "House #" + id;
-            String desc = (ownerName == null ? "Available" : "Owner: " + ownerName) + " Price: " + price;
-            Class<?> v3d = Class.forName("com.flowpowered.math.vector.Vector3d", true, bluemapLoader);
-            Object pos = v3d.getConstructor(double.class, double.class, double.class).newInstance(x + 0.5, (double) y, z + 0.5);
-            Class<?> poi = Class.forName("de.bluecolored.bluemap.api.markers.POIMarker", true, bluemapLoader);
-            for (Object set : bluemapSets) {
-                java.util.Map<String,Object> markers = (java.util.Map<String,Object>) set.getClass().getMethod("getMarkers").invoke(set);
-                Object marker = markers.get("house-" + id);
-                if (marker == null) {
-                    marker = poi.getConstructor(String.class, v3d).newInstance(label, pos);
-                    markers.put("house-" + id, marker);
-                } else {
-                    marker.getClass().getMethod("setPosition", v3d).invoke(marker, pos);
-                    marker.getClass().getMethod("setLabel", String.class).invoke(marker, label);
-                }
-                marker.getClass().getMethod("setDetail", String.class).invoke(marker, desc);
+        String path = "houses." + id;
+        int x = housesConfig.getInt(path + ".x");
+        int y = housesConfig.getInt(path + ".y");
+        int z = housesConfig.getInt(path + ".z");
+        boolean rent = housesConfig.getBoolean(path + ".rent");
+        double price = housesConfig.getDouble(path + ".price");
+        String owner = housesConfig.getString(path + ".owner");
+        String ownerName = owner == null ? null : Bukkit.getOfflinePlayer(java.util.UUID.fromString(owner)).getName();
+        String label = (rent ? "[Rent] " : "[Buy] ") + "House #" + id;
+        String desc = (ownerName == null ? "Available" : "Owner: " + ownerName) + " Price: " + price;
+        Vector3d pos = new Vector3d(x + 0.5, y, z + 0.5);
+        for (MarkerSet set : bluemapSets) {
+            java.util.Map<String, de.bluecolored.bluemap.api.markers.Marker> markers = set.getMarkers();
+            de.bluecolored.bluemap.api.markers.Marker base = markers.get("house-" + id);
+            if (!(base instanceof POIMarker)) {
+                POIMarker marker = POIMarker.builder()
+                        .label(label)
+                        .position(pos)
+                        .detail(desc)
+                        .build();
+                markers.put("house-" + id, marker);
+            } else {
+                POIMarker marker = (POIMarker) base;
+                marker.setPosition(pos);
+                marker.setLabel(label);
+                marker.setDetail(desc);
             }
-        } catch (Exception ex) {
-            getLogger().warning("BlueMap marker error: " + ex.getMessage());
         }
     }
 
     private void removeBlueMapMarker(int id) {
         if (bluemapSets.isEmpty()) return;
-        try {
-            for (Object set : bluemapSets) {
-                java.util.Map<?,?> markers = (java.util.Map<?,?>) set.getClass().getMethod("getMarkers").invoke(set);
-                markers.remove("house-" + id);
-            }
-        } catch (Exception ignored) {}
+        for (MarkerSet set : bluemapSets) {
+            set.getMarkers().remove("house-" + id);
+        }
     }
 
     private void checkRentPayments() {

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -315,8 +315,10 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             java.lang.reflect.Method onEnable = apiClass.getMethod("onEnable", consumerClass);
             java.lang.reflect.Method onDisable = apiClass.getMethod("onDisable", consumerClass);
 
+            ClassLoader loader = getClass().getClassLoader();
+
             bluemapEnableListener = java.lang.reflect.Proxy.newProxyInstance(
-                    consumerClass.getClassLoader(), new Class[]{consumerClass},
+                    loader, new Class[]{consumerClass},
                     (proxy, method, args) -> {
                         if ("accept".equals(method.getName())) {
                             setupBlueMap(args[0]);
@@ -326,7 +328,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
                     });
 
             bluemapDisableListener = java.lang.reflect.Proxy.newProxyInstance(
-                    consumerClass.getClassLoader(), new Class[]{consumerClass},
+                    loader, new Class[]{consumerClass},
                     (proxy, method, args) -> {
                         if ("accept".equals(method.getName())) {
                             removeAllBlueMapMarkers();

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -77,6 +77,9 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         startRentTask();
         startCleanupTask();
         new Metrics(this, 26286);
+        if (getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            new HousesPlaceholder(this).register();
+        }
                 getLogger().info("  ╭───────────────────────╮");
                 getLogger().info("  │      AlphaCTX's       │");
                 getLogger().info("  │        Houses         │");

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -62,6 +62,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     private final java.util.List<Object> bluemapSets = new java.util.ArrayList<>();
     private Object bluemapEnableListener;
     private Object bluemapDisableListener;
+    private ClassLoader bluemapLoader;
 
     private boolean useMysql() {
         return getConfig().getBoolean("database.use-mysql", false);
@@ -284,6 +285,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             } catch (Exception ignored) {}
             bluemapEnableListener = null;
             bluemapDisableListener = null;
+            bluemapLoader = null;
         }
     }
 
@@ -310,7 +312,11 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
 
     private void initBlueMap() {
         try {
-            Class<?> apiClass = Class.forName("de.bluecolored.bluemap.api.BlueMapAPI");
+            org.bukkit.plugin.Plugin bm = getServer().getPluginManager().getPlugin("BlueMap");
+            if (bm == null) return;
+            bluemapLoader = bm.getClass().getClassLoader();
+
+            Class<?> apiClass = Class.forName("de.bluecolored.bluemap.api.BlueMapAPI", true, bluemapLoader);
             Class<?> consumerClass = Class.forName("java.util.function.Consumer");
             java.lang.reflect.Method onEnable = apiClass.getMethod("onEnable", consumerClass);
             java.lang.reflect.Method onDisable = apiClass.getMethod("onDisable", consumerClass);
@@ -356,7 +362,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     private void setupBlueMap(Object api) throws Exception {
         bluemapSets.clear();
         java.util.Collection<?> maps = (java.util.Collection<?>) api.getClass().getMethod("getMaps").invoke(api);
-        Class<?> markerSetClass = Class.forName("de.bluecolored.bluemap.api.markers.MarkerSet");
+        Class<?> markerSetClass = Class.forName("de.bluecolored.bluemap.api.markers.MarkerSet", true, bluemapLoader);
         for (Object map : maps) {
             @SuppressWarnings("unchecked")
             java.util.Map<String, Object> sets = (java.util.Map<String, Object>) map.getClass().getMethod("getMarkerSets").invoke(map);
@@ -473,9 +479,9 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             String ownerName = owner == null ? null : Bukkit.getOfflinePlayer(java.util.UUID.fromString(owner)).getName();
             String label = (rent ? "[Rent] " : "[Buy] ") + "House #" + id;
             String desc = (ownerName == null ? "Available" : "Owner: " + ownerName) + " Price: " + price;
-            Class<?> v3d = Class.forName("com.flowpowered.math.vector.Vector3d");
+            Class<?> v3d = Class.forName("com.flowpowered.math.vector.Vector3d", true, bluemapLoader);
             Object pos = v3d.getConstructor(double.class, double.class, double.class).newInstance(x + 0.5, (double) y, z + 0.5);
-            Class<?> poi = Class.forName("de.bluecolored.bluemap.api.markers.POIMarker");
+            Class<?> poi = Class.forName("de.bluecolored.bluemap.api.markers.POIMarker", true, bluemapLoader);
             for (Object set : bluemapSets) {
                 java.util.Map<String,Object> markers = (java.util.Map<String,Object>) set.getClass().getMethod("getMarkers").invoke(set);
                 Object marker = markers.get("house-" + id);

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -55,6 +55,12 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     private int rentTask = -1;
     private int cleanupTask = -1;
 
+    private boolean dynmapEnabled;
+    private boolean bluemapEnabled;
+    private Object dynmapMarkerAPI;
+    private Object dynmapMarkerSet;
+    private final java.util.List<Object> bluemapSets = new java.util.ArrayList<>();
+
     private boolean useMysql() {
         return getConfig().getBoolean("database.use-mysql", false);
     }
@@ -80,6 +86,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         if (getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             new HousesPlaceholder(this).register();
         }
+        setupMapIntegrations();
                 getLogger().info("  ╭───────────────────────╮");
                 getLogger().info("  │      AlphaCTX's       │");
                 getLogger().info("  │        Houses         │");
@@ -95,6 +102,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         stopRentTask();
         stopCleanupTask();
         closeDatabase();
+        cleanupMapIntegrations();
                 getLogger().info("Houses Disabled!");
     }
 
@@ -125,6 +133,8 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         connectDatabase();
         loadHousesFromDatabase();
         startAutoSave();
+        cleanupMapIntegrations();
+        setupMapIntegrations();
     }
     /**
      * Save houses asynchronously to avoid blocking the server thread.
@@ -245,6 +255,204 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         }
     }
 
+    private void setupMapIntegrations() {
+        dynmapEnabled = getConfig().getBoolean("integrations.dynmap", false);
+        bluemapEnabled = getConfig().getBoolean("integrations.bluemap", false);
+        if (dynmapEnabled) initDynmap();
+        if (bluemapEnabled) initBlueMap();
+    }
+
+    private void cleanupMapIntegrations() {
+        if (dynmapMarkerSet != null) {
+            removeAllDynmapMarkers();
+            dynmapMarkerSet = null;
+            dynmapMarkerAPI = null;
+        }
+        if (!bluemapSets.isEmpty()) {
+            removeAllBlueMapMarkers();
+            bluemapSets.clear();
+        }
+    }
+
+    private void initDynmap() {
+        try {
+            org.bukkit.plugin.Plugin dyn = getServer().getPluginManager().getPlugin("dynmap");
+            if (dyn == null) return;
+            Class<?> apiClass = Class.forName("org.dynmap.DynmapCommonAPI");
+            if (!apiClass.isInstance(dyn)) return;
+            dynmapMarkerAPI = apiClass.getMethod("getMarkerAPI").invoke(dyn);
+            if (dynmapMarkerAPI == null) return;
+            Class<?> markerAPI = Class.forName("org.dynmap.markers.MarkerAPI");
+            Object set = markerAPI.getMethod("getMarkerSet", String.class).invoke(dynmapMarkerAPI, "houses");
+            if (set == null) {
+                set = markerAPI.getMethod("createMarkerSet", String.class, String.class, java.util.Set.class, boolean.class)
+                        .invoke(dynmapMarkerAPI, "houses", "Houses", null, true);
+            }
+            dynmapMarkerSet = set;
+        } catch (Exception ex) {
+            getLogger().warning("Dynmap hook failed: " + ex.getMessage());
+        }
+        updateAllDynmapMarkers();
+    }
+
+    private void initBlueMap() {
+        try {
+            Class<?> apiClass = Class.forName("de.bluecolored.bluemap.api.BlueMapAPI");
+            java.util.Optional<?> opt = (java.util.Optional<?>) apiClass.getMethod("getInstance").invoke(null);
+            if (!((Boolean) opt.getClass().getMethod("isPresent").invoke(opt))) return;
+            Object api = opt.getClass().getMethod("get").invoke(opt);
+            java.util.Collection<?> maps = (java.util.Collection<?>) apiClass.getMethod("getMaps").invoke(api);
+            Class<?> markerSetClass = Class.forName("de.bluecolored.bluemap.api.markers.MarkerSet");
+            for (Object map : maps) {
+                java.util.Map<?,?> sets = (java.util.Map<?,?>) map.getClass().getMethod("getMarkerSets").invoke(map);
+                Object set = sets.get("houses");
+                if (set == null) {
+                    Object builder = markerSetClass.getMethod("builder").invoke(null);
+                    builder.getClass().getMethod("label", String.class).invoke(builder, "Houses");
+                    builder.getClass().getMethod("toggleable", Boolean.class).invoke(builder, true);
+                    set = builder.getClass().getMethod("build").invoke(builder);
+                    sets.put("houses", set);
+                }
+                bluemapSets.add(set);
+            }
+        } catch (Exception ex) {
+            getLogger().warning("BlueMap hook failed: " + ex.getMessage());
+            bluemapSets.clear();
+        }
+        updateAllBlueMapMarkers();
+    }
+
+    private void updateMapMarkers(int id) {
+        updateDynmapMarker(id);
+        updateBlueMapMarker(id);
+    }
+
+    private void removeMapMarker(int id) {
+        removeDynmapMarker(id);
+        removeBlueMapMarker(id);
+    }
+
+    private void updateAllMapMarkers() {
+        if (housesConfig.isConfigurationSection("houses")) {
+            for (String idStr : housesConfig.getConfigurationSection("houses").getKeys(false)) {
+                try { updateMapMarkers(Integer.parseInt(idStr)); } catch (Exception ignored) {}
+            }
+        }
+    }
+
+    private void removeAllDynmapMarkers() {
+        if (dynmapMarkerSet == null) return;
+        try {
+            java.util.Set<?> markers = (java.util.Set<?>) dynmapMarkerSet.getClass().getMethod("getMarkers").invoke(dynmapMarkerSet);
+            for (Object m : markers.toArray()) {
+                m.getClass().getMethod("deleteMarker").invoke(m);
+            }
+        } catch (Exception ignored) {}
+    }
+
+    private void removeAllBlueMapMarkers() {
+        try {
+            for (Object set : bluemapSets) {
+                java.util.Map<?,?> markers = (java.util.Map<?,?>) set.getClass().getMethod("getMarkers").invoke(set);
+                markers.clear();
+            }
+        } catch (Exception ignored) {}
+    }
+
+    private void updateAllDynmapMarkers() {
+        if (dynmapMarkerSet != null)
+            updateAllMapMarkers();
+    }
+
+    private void updateAllBlueMapMarkers() {
+        if (!bluemapSets.isEmpty())
+            updateAllMapMarkers();
+    }
+
+    private void updateDynmapMarker(int id) {
+        if (dynmapMarkerSet == null) return;
+        try {
+            String path = "houses." + id;
+            String world = housesConfig.getString(path + ".world");
+            if (world == null) return;
+            double x = housesConfig.getDouble(path + ".x") + 0.5;
+            double y = housesConfig.getDouble(path + ".y");
+            double z = housesConfig.getDouble(path + ".z") + 0.5;
+            boolean rent = housesConfig.getBoolean(path + ".rent");
+            double price = housesConfig.getDouble(path + ".price");
+            String owner = housesConfig.getString(path + ".owner");
+            String ownerName = owner == null ? null : Bukkit.getOfflinePlayer(java.util.UUID.fromString(owner)).getName();
+            String label = "House #" + id;
+            String desc = (ownerName == null ? "Available" : "Owner: " + ownerName) + "<br>Price: " + price + (rent ? " rent" : " buy");
+            Class<?> markerSet = dynmapMarkerSet.getClass();
+            Object marker = markerSet.getMethod("findMarker", String.class).invoke(dynmapMarkerSet, "house-" + id);
+            Class<?> markerAPI = Class.forName("org.dynmap.markers.MarkerAPI");
+            Object icon = markerAPI.getMethod("getMarkerIcon", String.class).invoke(dynmapMarkerAPI, "default");
+            if (marker == null) {
+                marker = markerSet.getMethod("createMarker", String.class, String.class, String.class, double.class, double.class, double.class, Class.forName("org.dynmap.markers.MarkerIcon"), boolean.class)
+                        .invoke(dynmapMarkerSet, "house-" + id, label, world, x, y, z, icon, true);
+            } else {
+                marker.getClass().getMethod("setLocation", String.class, double.class, double.class, double.class)
+                        .invoke(marker, world, x, y, z);
+                marker.getClass().getMethod("setLabel", String.class).invoke(marker, label);
+            }
+            marker.getClass().getMethod("setDescription", String.class).invoke(marker, desc);
+        } catch (Exception ex) {
+            getLogger().warning("Dynmap marker error: " + ex.getMessage());
+        }
+    }
+
+    private void removeDynmapMarker(int id) {
+        if (dynmapMarkerSet == null) return;
+        try {
+            Object marker = dynmapMarkerSet.getClass().getMethod("findMarker", String.class).invoke(dynmapMarkerSet, "house-" + id);
+            if (marker != null) marker.getClass().getMethod("deleteMarker").invoke(marker);
+        } catch (Exception ignored) {}
+    }
+
+    private void updateBlueMapMarker(int id) {
+        if (bluemapSets.isEmpty()) return;
+        try {
+            String path = "houses." + id;
+            int x = housesConfig.getInt(path + ".x");
+            int y = housesConfig.getInt(path + ".y");
+            int z = housesConfig.getInt(path + ".z");
+            boolean rent = housesConfig.getBoolean(path + ".rent");
+            double price = housesConfig.getDouble(path + ".price");
+            String owner = housesConfig.getString(path + ".owner");
+            String ownerName = owner == null ? null : Bukkit.getOfflinePlayer(java.util.UUID.fromString(owner)).getName();
+            String label = (rent ? "[Rent] " : "[Buy] ") + "House #" + id;
+            String desc = (ownerName == null ? "Available" : "Owner: " + ownerName) + " Price: " + price;
+            Class<?> v3d = Class.forName("com.flowpowered.math.vector.Vector3d");
+            Object pos = v3d.getConstructor(double.class, double.class, double.class).newInstance(x + 0.5, (double) y, z + 0.5);
+            Class<?> poi = Class.forName("de.bluecolored.bluemap.api.markers.POIMarker");
+            for (Object set : bluemapSets) {
+                java.util.Map<String,Object> markers = (java.util.Map<String,Object>) set.getClass().getMethod("getMarkers").invoke(set);
+                Object marker = markers.get("house-" + id);
+                if (marker == null) {
+                    marker = poi.getConstructor(String.class, v3d).newInstance(label, pos);
+                    markers.put("house-" + id, marker);
+                } else {
+                    marker.getClass().getMethod("setPosition", v3d).invoke(marker, pos);
+                    marker.getClass().getMethod("setLabel", String.class).invoke(marker, label);
+                }
+                marker.getClass().getMethod("setDetail", String.class).invoke(marker, desc);
+            }
+        } catch (Exception ex) {
+            getLogger().warning("BlueMap marker error: " + ex.getMessage());
+        }
+    }
+
+    private void removeBlueMapMarker(int id) {
+        if (bluemapSets.isEmpty()) return;
+        try {
+            for (Object set : bluemapSets) {
+                java.util.Map<?,?> markers = (java.util.Map<?,?>) set.getClass().getMethod("getMarkers").invoke(set);
+                markers.remove("house-" + id);
+            }
+        } catch (Exception ignored) {}
+    }
+
     private void checkRentPayments() {
         checkRentPayments(null);
     }
@@ -333,6 +541,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
                 housesConfig.set(path + ".trusted", trusted == null || trusted.isEmpty() ? new ArrayList<>() : Arrays.asList(trusted.split(";")));
             }
             housesConfig.set("lastId", lastId);
+            updateAllMapMarkers();
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -442,6 +651,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         e.setLine(1, "$" + price);
         e.setLine(2, "");
         e.setLine(3, "ID: " + id);
+        updateMapMarkers(id);
     }
 
     @EventHandler
@@ -459,6 +669,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         if (e.getPlayer().hasPermission("houses.admin")) {
             housesConfig.set("houses." + id, null);
             saveHouses();
+            removeMapMarker(id);
             e.getPlayer().sendMessage(ChatColor.YELLOW + "[Houses]" + ChatColor.GREEN + "House " + id + " removed");
         }
     }
@@ -676,6 +887,7 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
             sign.setLine(3, "ID: " + id);
             sign.update();
         }
+        updateMapMarkers(id);
     }
 
     private void buyHouse(Player p, int id) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -46,3 +46,10 @@ messages:
   rent-paid: "&aRent for house {id} paid"
   rent-stopped: "&cRent unpaid, house {id} lost"
   inactive-removed: "&cHouse {id} removed due to inactivity"
+
+#===========================
+#=       MAP SETTINGS     =
+#===========================
+integrations:
+  dynmap: false
+  bluemap: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: 1.2.0
 main: com.alphactx.MinecraftHouses
 api-version: 1.16
 depend: [Vault]
+softdepend: [PlaceholderAPI]
 commands:
   houses:
     description: House commands
@@ -11,6 +12,8 @@ commands:
     tab-completer: com.alphactx.HousesCommand
 permissions:
   mchouses.use:
+    default: true
+  houses.use:
     default: true
   houses.admin:
     default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: 1.2.1
 main: com.alphactx.MinecraftHouses
 api-version: 1.16
 depend: [Vault]
-softdepend: [PlaceholderAPI]
+softdepend: [PlaceholderAPI, dynmap, BlueMap]
 commands:
   houses:
     description: House commands

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: MinecraftHouses
-version: 1.2.0
+version: 1.2.1
 main: com.alphactx.MinecraftHouses
 api-version: 1.16
 depend: [Vault]


### PR DESCRIPTION
## Summary
- add PlaceholderAPI dependency
- implement HousesPlaceholder for custom placeholders
- register expansion if PlaceholderAPI present
- check `houses.use` permission for basic commands
- expose new permission and softdepend in plugin.yml

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68690911d8c48329a7785e1dc46d994c