### PR TITLE
Fix BlueMap marker formatting and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ database set `database.use-mysql` to `true` in `config.yml` and adjust the
 `host`, `port`, `user`, `pass` and `database` settings. When MySQL is enabled
 data is saved automatically every `database.save-interval` seconds. Set
 `database.debug` to `true` to print SQL operations to the console.
+
+The `sell-percentage` option controls what fraction of a house's price a player
+receives back when selling. The default is `0.75` which means selling a house
+returns 75% of its purchase price.

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.api.markers.POIMarker;
 import com.flowpowered.math.vector.Vector3d;
 
 import java.io.File;
+import java.util.stream.Collectors;
 import java.util.*;
 import java.sql.*;
 

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -675,9 +675,16 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
     }
 
     private void sendConfiguredMessage(Player player, String key, int id) {
+        sendConfiguredMessage(player, key, id, -1);
+    }
+
+    private void sendConfiguredMessage(Player player, String key, int id, double price) {
         String msg = getConfig().getString("messages." + key);
         if (msg != null) {
             msg = msg.replace("{id}", String.valueOf(id));
+            if (msg.contains("{price}")) {
+                msg = msg.replace("{price}", String.valueOf(price));
+            }
             player.sendMessage(ChatColor.translateAlternateColorCodes('&', msg));
         }
     }
@@ -842,8 +849,9 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
                 p.sendMessage(ChatColor.YELLOW + "[Houses]" + ChatColor.GRAY + "Sneak and right click to confirm");
             }
         } else if (owner.equals(p.getUniqueId().toString())) {
-            double sellPrice = price * 0.75;
-            p.sendMessage(ChatColor.YELLOW + "Sell price: " + sellPrice);
+            double percent = getConfig().getDouble("sell-percentage", 0.75);
+            double sellPrice = price * percent;
+            sendConfiguredMessage(p, "sell-price-info", id, sellPrice);
             if (p.isSneaking()) {
                 economy.depositPlayer(p, sellPrice);
                 housesConfig.set(path + ".owner", null);
@@ -1003,7 +1011,8 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         String path = "houses." + id;
         boolean rent = housesConfig.getBoolean(path + ".rent");
         double price = housesConfig.getDouble(path + ".price");
-        double sellPrice = price * 0.75;
+        double percent = getConfig().getDouble("sell-percentage", 0.75);
+        double sellPrice = price * percent;
         economy.depositPlayer(p, sellPrice);
         housesConfig.set(path + ".owner", null);
         housesConfig.set(path + ".trusted", new ArrayList<>());

--- a/src/main/java/com/alphactx/MinecraftHouses.java
+++ b/src/main/java/com/alphactx/MinecraftHouses.java
@@ -24,7 +24,7 @@ import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.plugin.RegisteredServiceProvider;F
+import org.bukkit.plugin.RegisteredServiceProvider;
 import net.milkbowl.vault.economy.Economy;
 import org.bstats.bukkit.Metrics;
 import de.bluecolored.bluemap.api.BlueMapAPI;
@@ -432,8 +432,13 @@ public class MinecraftHouses extends JavaPlugin implements Listener {
         double price = housesConfig.getDouble(path + ".price");
         String owner = housesConfig.getString(path + ".owner");
         String ownerName = owner == null ? null : Bukkit.getOfflinePlayer(java.util.UUID.fromString(owner)).getName();
-        String label = (rent ? "[Rent] " : "[Buy] ") + "House #" + id;
-        String desc = (ownerName == null ? "Available" : "Owner: " + ownerName) + " Price: " + price;
+        String label = "<b>[" + (rent ? "Rentable" : "Purchasable") + " property]</b>";
+        StringBuilder descBuilder = new StringBuilder();
+        descBuilder.append("Price: ").append(price)
+                .append("<br>Number: ").append(id)
+                .append("<br>Owner: ")
+                .append(ownerName == null ? "none" : ownerName);
+        String desc = descBuilder.toString();
         Vector3d pos = new Vector3d(x + 0.5, y, z + 0.5);
         for (MarkerSet set : bluemapSets) {
             java.util.Map<String, de.bluecolored.bluemap.api.markers.Marker> markers = set.getMarkers();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,10 +3,11 @@
 #===================================
 # 
 #
-#================================
-#=     MAX OWNED PROPERTIES     =
-#================================
+#============================
+#=     GENERAL SETTINGS    =
+#============================
 max-houses-per-player: 3
+sell-percentage: 0.75
 
 #============================
 #=     STOREAGE OPTIONS     =
@@ -19,22 +20,20 @@ database:
   pass: password
   database: houses
   sqlite-file: houses.db
-  save-interval: 60 # seconds
+  save-interval: 60            # Seconds
   debug: false
+
+  cleanup:                     # Removes ownership of houses from inactive players
+  check-interval: 86400        # Seconds
+  inactive-days: 30
 
 #=============================
 #=     TELEPORT SETTINGS     =
 #=============================
 teleport-wait: 5
 rent:
-  period: 2400 # seconds (2 Minecraft days)
-  check-interval: 600 # seconds
-
-cleanup:
-  check-interval: 86400 # seconds
-  inactive-days: 30
-
-sell-percentage: 0.75 # fraction of price returned when selling
+  period: 2400                 # Seconds (2 Minecraft days)
+  check-interval: 600          # Seconds
 
 #===========================
 #=     CUSTOM MESSAGES     =
@@ -51,8 +50,8 @@ messages:
   sell-price-info: "&eSell price: {price}"
 
 #===========================
-#=       MAP SETTINGS     =
+#=       MAP SETTINGS      =
 #===========================
 integrations:
-  dynmap: false
-  bluemap: false
+  dynmap: false              # Adds Houses markers on Dynmap
+  bluemap: false             # Adds Houses markers on Bluemap

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -34,6 +34,8 @@ cleanup:
   check-interval: 86400 # seconds
   inactive-days: 30
 
+sell-percentage: 0.75 # fraction of price returned when selling
+
 #===========================
 #=     CUSTOM MESSAGES     =
 #===========================
@@ -46,6 +48,7 @@ messages:
   rent-paid: "&aRent for house {id} paid"
   rent-stopped: "&cRent unpaid, house {id} lost"
   inactive-removed: "&cHouse {id} removed due to inactivity"
+  sell-price-info: "&eSell price: {price}"
 
 #===========================
 #=       MAP SETTINGS     =


### PR DESCRIPTION
## Summary
- clean up the RegisteredServiceProvider import
- enhance BlueMap markers to show price, number and owner in detail

## Testing
- `mvn -q -f pom-1.16.xml -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686a5700bfd48329bdf66a08b3d0c28a